### PR TITLE
Add support for *BLOB types as well as TINYTEXT

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# PHP PSR-2 Coding Standards
+# http://www.php-fig.org/psr/psr-2/
+
+root = true
+
+[*.php]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -4,12 +4,21 @@ What it gives?
 It adds new features to Schema which you can use in your migrations:
 ```php
 Schema::create('tests', function ($table) {
-    $table->increments('id');
-    $table->string('description', 1000)->collate('utf8_general_ci');
     $table->binary('md5', 16); // will use BINARY(16) instead of BLOB
-    $table->binary('sha1', 20); // will use BINARY(20) instead of BLOB
-    $table->boolean('enabled')->comment('columns comment');
-    $table->comment = 'table comment';
+    $table->binary('different'); // default BINARY(255), still not BLOB
+
+    $table->set('flags', ['a', 'b', 'c', 'd']); // SET('a', 'b', 'c', 'd')
+
+    $table->tinyText('sometext'); // TINYTEXT -- other sizes already supported
+
+    $table->tinyBlob('someblob'); // TINYBLOB
+    $table->blob('biggerblob'); // BLOB -- like Illuminate's binary() method
+    $table->mediumBlob('evenbiggerblob'); // MEDIUMBLOB
+    $table->longBlob('biggestblob'); // LONGBLOB
+
+    $table->index('sometext', 'foo', 10); // Third param is index length not
+                                          // algorithm like in Illuminate
+    $table->unique('someblob', null, 10); // null for automatic naming
 });
 
 ```
@@ -17,12 +26,12 @@ Schema::create('tests', function ($table) {
 What versions of Laravel are supported
 --------------------------------------
 
-It have been tested only with Laravel 5.0. But you can try it with Laravel 5.1 too.
+It has been tested to work with Laravel 5.0 and 5.5.
 
 How to install
 --------------
 
-Add package to `package.json`
+Add package to `composer.json`
 ```json
 "repositories": [
     {
@@ -36,7 +45,7 @@ Add package to `package.json`
 },
 ```
 
-Do not forget to run `composer install` or `composer update rafis/schema-extended` after modifying `package.json`.
+Do not forget to run `composer install` or `composer update rafis/schema-extended` after modifying `composer.json`.
 
 Replace "alias" in the configuration file `config/app.php`:
 ```php

--- a/src/SchemaExtended/Blueprint.php
+++ b/src/SchemaExtended/Blueprint.php
@@ -5,8 +5,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint as IlluminateBlueprint;
 
 /**
- * Extended version of Blueprint with
- * support of 'set' data type
+ * Extended version of Blueprint with support for additional data types.
  */
 class Blueprint extends IlluminateBlueprint {
 
@@ -20,6 +19,62 @@ class Blueprint extends IlluminateBlueprint {
     public function binary($column, $length = 255)
     {
         return $this->addColumn('binary', $column, compact('length'));
+    }
+
+    /**
+     * Create a new tinytext column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function tinyText($column)
+    {
+        return $this->addColumn('tinytext', $column);
+    }
+
+    /**
+     * Create a new tinyblob column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function tinyBlob($column)
+    {
+        return $this->addColumn('tinyblob', $column);
+    }
+
+    /**
+     * Create a new blob column on the table. Corresponds to the core binary()
+     * method.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function blob($column)
+    {
+        return $this->addColumn('blob', $column);
+    }
+
+    /**
+     * Create a new mediumblob column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function mediumBlob($column)
+    {
+        return $this->addColumn('mediumblob', $column);
+    }
+
+    /**
+     * Create a new longblob column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function longBlob($column)
+    {
+        return $this->addColumn('longblob', $column);
     }
 
     /**

--- a/src/SchemaExtended/Blueprint.php
+++ b/src/SchemaExtended/Blueprint.php
@@ -7,8 +7,8 @@ use Illuminate\Database\Schema\Blueprint as IlluminateBlueprint;
 /**
  * Extended version of Blueprint with support for additional data types.
  */
-class Blueprint extends IlluminateBlueprint {
-
+class Blueprint extends IlluminateBlueprint
+{
     /**
      * Create a new binary column on the table.
      *
@@ -147,12 +147,10 @@ class Blueprint extends IlluminateBlueprint {
         // If no name was specified for this index, we will create one using a basic
         // convention of the table name, followed by the columns, followed by an
         // index type, such as primary or index, which makes the index unique.
-        if (is_null($index))
-        {
+        if (is_null($index)) {
             $index = $this->createIndexName($type, $columns);
         }
 
         return $this->addCommand($type, compact('index', 'columns', 'length'));
     }
-
 }

--- a/src/SchemaExtended/MySqlGrammar.php
+++ b/src/SchemaExtended/MySqlGrammar.php
@@ -6,8 +6,7 @@ use Illuminate\Database\Schema\Grammars\MySqlGrammar as IlluminateMySqlGrammar;
 use Illuminate\Database\Schema\Blueprint as IlluminateBlueprint;
 
 /**
- * Extended version of MySqlGrammar with
- * support of 'set' data type
+ * Extended version of MySqlGrammar with support for additional data types.
  */
 class MySqlGrammar extends IlluminateMySqlGrammar {
 
@@ -92,6 +91,62 @@ class MySqlGrammar extends IlluminateMySqlGrammar {
     protected function typeBinary(Fluent $column)
     {
         return "binary({$column->length})";
+    }
+
+    /**
+     * Create the column definition for a tinytext type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeTinytext(Fluent $column)
+    {
+        return "tinytext";
+    }
+
+    /**
+     * Create the column definition for a tinyblob type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeTinyblob(Fluent $column)
+    {
+        return "tinyblob";
+    }
+
+    /**
+     * Create the column definition for a blob type. Corresponds to the core
+     * binary type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeBlob(Fluent $column)
+    {
+        return "blob";
+    }
+
+    /**
+     * Create the column definition for a mediumblob type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeMediumblob(Fluent $column)
+    {
+        return "mediumblob";
+    }
+
+    /**
+     * Create the column definition for a longblob type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeLongblob(Fluent $column)
+    {
+        return "longblob";
     }
 
     /**

--- a/src/SchemaExtended/MySqlGrammar.php
+++ b/src/SchemaExtended/MySqlGrammar.php
@@ -8,23 +8,31 @@ use Illuminate\Database\Schema\Blueprint as IlluminateBlueprint;
 /**
  * Extended version of MySqlGrammar with support for additional data types.
  */
-class MySqlGrammar extends IlluminateMySqlGrammar {
-
+class MySqlGrammar extends IlluminateMySqlGrammar
+{
     /**
-     * 
      * @return void
      */
     public function __construct()
     {
-        if ( ! in_array('Collate', $this->modifiers) )
+        if (!in_array('Collate', $this->modifiers))
         {
-            array_splice($this->modifiers, array_search('Unsigned', $this->modifiers) + 1, 0, 'Collate');
+            array_splice(
+                $this->modifiers,
+                array_search('Unsigned', $this->modifiers) + 1,
+                0,
+                'Collate'
+            );
         }
 
         // new versions of Laravel already have comment modifier
-        if ( ! in_array('Comment', $this->modifiers) )
-        {
-            array_splice($this->modifiers, array_search('After', $this->modifiers) - 1, 0, 'Comment');
+        if (!in_array('Comment', $this->modifiers)) {
+            array_splice(
+                $this->modifiers,
+                array_search('After', $this->modifiers) - 1,
+                0,
+                'Comment'
+            );
         }
     }
 
@@ -35,10 +43,11 @@ class MySqlGrammar extends IlluminateMySqlGrammar {
      * @param \Illuminate\Support\Fluent             $column
      * @return string|null
      */
-    protected function modifyCollate(IlluminateBlueprint $blueprint, Fluent $column)
-    {
-        if ( ! is_null($column->collate) )
-        {
+    protected function modifyCollate(
+        IlluminateBlueprint $blueprint,
+        Fluent $column
+    ) {
+        if (!is_null($column->collate)) {
             $characterSet = strtok($column->collate, '_');
             return " character set $characterSet collate {$column->collate}";
         }
@@ -51,10 +60,11 @@ class MySqlGrammar extends IlluminateMySqlGrammar {
      * @param \Illuminate\Support\Fluent             $column
      * @return string|null
      */
-    protected function modifyComment(IlluminateBlueprint $blueprint, Fluent $column)
-    {
-        if ( ! is_null($column->comment) )
-        {
+    protected function modifyComment(
+        IlluminateBlueprint $blueprint,
+        Fluent $column
+    ) {
+        if (!is_null($column->comment)) {
             $comment = str_replace("'", "\'", $column->comment);
             return " comment '$comment'";
         }
@@ -68,13 +78,15 @@ class MySqlGrammar extends IlluminateMySqlGrammar {
      * @param  \Illuminate\Database\Connection  $connection
      * @return string
      */
-    public function compileCreate(IlluminateBlueprint $blueprint, Fluent $command, Connection $connection)
-    {
+    public function compileCreate(
+        IlluminateBlueprint $blueprint,
+        Fluent $command,
+        Connection $connection
+    ) {
         $sql = parent::compileCreate($blueprint, $command, $connection);
 
         // Table annotation support
-        if ( isset($blueprint->comment) )
-        {
+        if (isset($blueprint->comment)) {
             $comment = str_replace("'", "\'", $blueprint->comment);
             $sql .= " comment = '$comment'";
         }
@@ -168,32 +180,29 @@ class MySqlGrammar extends IlluminateMySqlGrammar {
      * @param  string  $type
      * @return string
      */
-    protected function compileKey(IlluminateBlueprint $blueprint, Fluent $command, $type)
-    {
+    protected function compileKey(
+        IlluminateBlueprint $blueprint,
+        Fluent $command,
+        $type
+    ) {
         $columns = [];
-        foreach($command->columns as $commandColumn)
-        {
-            foreach($blueprint->getColumns() as $blueprintColumn)
-            {
-                if ( $blueprintColumn->name != $commandColumn )
-                {
+        foreach($command->columns as $commandColumn) {
+            foreach($blueprint->getColumns() as $blueprintColumn) {
+                if ($blueprintColumn->name != $commandColumn) {
                     continue;
                 }
-                
+
                 $column = $this->wrap($commandColumn);
-                if ( isset($command->length) )
-                {
+                if (isset($command->length)) {
                     $column .= "({$command->length})";
-                }
-                elseif ( 'string' == $blueprintColumn->type && $blueprintColumn->length > 255 )
-                {
+                } elseif ('string' == $blueprintColumn->type && $blueprintColumn->length > 255) {
                     $column .= '(255)';
                 }
-                
+
                 $columns[] = $column;
             }
         }
-        
+
         $columns = implode(', ', $columns);
 
         $table = $this->wrapTable($blueprint);

--- a/src/SchemaExtended/Schema.php
+++ b/src/SchemaExtended/Schema.php
@@ -39,12 +39,12 @@ class Schema extends \Illuminate\Support\Facades\Facade
             $MySqlGrammar = $connection->withTablePrefix(new MySqlGrammar);
             $connection->setSchemaGrammar($MySqlGrammar);
         }
-        
+
         $schema = $connection->getSchemaBuilder();
         $schema->blueprintResolver(function($table, $callback) {
             return new Blueprint($table, $callback);
         });
-        
+
         return $schema;
     }
 


### PR DESCRIPTION
* Add support for the following types:
  * `Blueprint::tinyText()` -- `TINYTEXT`
  * `Blueprint::tinyBlob()` -- `TINYBLOB`
  * `Blueprint::blob()` -- `BLOB` (like Illuminate's `Blueprint::binary()`)
  * `Blueprint::mediumBlob()` -- `MEDIUMBLOB`
  * `Blueprint::longBlob()` -- `LONGBLOB`
* Update `README.md`:
  * Add sample usage of new methods
  * Remove references to Illuminate methods to highlight new features
  * Correct `package.json` to `composer.json`
* Reformat for PSR-2
* Add PSR-2 editorconfig file